### PR TITLE
安装预编译版本的 TinyTeX 而不是 travis-bin.yihui.org 上的 TinyTeX

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,9 +34,8 @@ addons:
 
 before_install:
   # TinyTeX
-  - curl -fLo /tmp/tinytex.tar.gz https://travis-bin.yihui.name/tinytex.tar.gz
-  - tar -xzf /tmp/tinytex.tar.gz -C $HOME
-  - export PATH=$HOME/.TinyTeX/bin/x86_64-linux:$PATH
+  - Rscript -e 'install.packages("tinytex"); tinytex:::install_prebuilt()'
+  - export PATH=$HOME/bin:$PATH
   - tlmgr repository list
   #- tlmgr repository add https://mirrors.tuna.tsinghua.edu.cn/CTAN/systems/texlive/tlnet
   - tlmgr option repository https://mirrors.tuna.tsinghua.edu.cn/CTAN/systems/texlive/tlnet

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,9 +36,6 @@ before_install:
   # TinyTeX
   - Rscript -e 'install.packages("tinytex"); tinytex:::install_prebuilt()'
   - export PATH=$HOME/bin:$PATH
-  - tlmgr repository list
-  #- tlmgr repository add https://mirrors.tuna.tsinghua.edu.cn/CTAN/systems/texlive/tlnet
-  - tlmgr option repository https://mirrors.tuna.tsinghua.edu.cn/CTAN/systems/texlive/tlnet
   - tlmgr update --self --all
   - tlmgr install hyphen-german elegantbook comment ctex ttfutils ms xecjk ulem zhnumber listings
       cancel kastrup newtx fontaxes anyfontsize esint xcolor enumitem jknapltx mdwtools


### PR DESCRIPTION
因为前者有保障，一定是可用的 TeX Live（只有通过我的一些测试后才发布）；后者没有测试的保障，有时候 TeX Live 自己就崩了，而他们自己似乎也不在乎测试：https://github.com/TeX-Live/installer/pull/14